### PR TITLE
Update guild.py

### DIFF
--- a/ferris/guild.py
+++ b/ferris/guild.py
@@ -41,7 +41,7 @@ class Guild(BaseObject):
 
         self._members: Dict[int, Member] = {}
 
-        for m in data.get('members', []):
+        for m in data.get('members') or []:
             member = Member(self._connection, m)
             self._members[member.id] = member
 

--- a/ferris/guild.py
+++ b/ferris/guild.py
@@ -35,7 +35,7 @@ class Guild(BaseObject):
 
         self._channels: Dict[int, Channel] = {}
 
-        for c in data.get('channels', []):
+        for c in data.get('channels') or []:
             channel = Channel(self._connection, c)
             self._channels[channel.id] = channel
 


### PR DESCRIPTION
Server currently returns None for channels and members on new guilds, which causes `TypeError: 'NoneType' object is not iterable`
Fix this by making the None returned by the server into an empty list, getting rid of the error


